### PR TITLE
Remove Found.no/play as it's gone and add Upgrade Assistant

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,8 +156,8 @@
           <li class="es6"><a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.x/index.html">Elasticsearch Reference</a>, official documentation;</li>
 
           <li><a href="https://github.com/dzharii/awesome-elasticsearch">Awesome Elasticsearch</a>, curated list of resources about ES;</li>
-          <li><a href="https://www.found.no/play">Found Play</a>, JSFiddle-like playground for Elasticsearch;</li>
-          <li><a href="https://discuss.elastic.co/">Official forum</a> and <a href="http://stackoverflow.com/questions/tagged/elasticsearch">StackOverflow</a> for support.</li>
+          <li><a href="https://discuss.elastic.co/">Official forum</a> and <a href="http://stackoverflow.com/questions/tagged/elasticsearch">StackOverflow</a> for support;</li>
+          <li><a href="https://www.elastic.co/products/upgrade_guide">Official online migration tool</a> to help upgrading the stack</a>.</li> 
         </ul>
 
 


### PR DESCRIPTION
https://www.found.no/play is dead :sob: but I just found a great migration assistant in the documentation: https://www.elastic.co/products/upgrade_guide


![image](https://user-images.githubusercontent.com/225704/47279623-9dacdc00-d5d2-11e8-8610-37ca74793198.png)
