### PR TITLE
Removed duplicate - GET /my_index_name/_stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -729,7 +729,6 @@
     <h3 class="ui header">Indices monitoring and information</h3>
 
     <pre><code>GET /my_index_name/_stats</code></pre>
-    <pre><code>GET /my_index_name/_stats</code></pre>
     <pre><code>GET /my_index_name/_segments</code></pre>
     <pre><code>GET /my_index_name/_recovery?pretty&amp;human</code></pre>
     <pre class="es1 es2"><code>GET /my_index_name/_warmer/*</code></pre>


### PR DESCRIPTION
Noticed that there was two entries for `GET /my_index_name/_stats` and removed one of them.