### PR TITLE
#33 Add links Cerebro and Comrade

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,10 +174,12 @@
           <li class="es6"><a href="https://www.elastic.co/guide/en/elasticsearch/reference/6.x/index.html">Elasticsearch Reference</a>, official documentation;</li>
           <li class="es7"><a href="https://www.elastic.co/guide/en/elasticsearch/reference/7.x/index.html">Elasticsearch Reference</a>, official documentation;</li>
 
-          <li><a class="es5 es6 es7" href="https://www.docker.elastic.co/">Docker repository</a>, quick start any Elastic software;</li>
+          <li class="es5 es6 es7"><a href="https://www.docker.elastic.co/">Docker repository</a>, quick start any Elastic software;</li>
           <li><a href="https://dev.to/t/elasticsearch">Dev.to Elasticsearch</a>, great source of content about Elastic;</li>
           <li><a href="https://discuss.elastic.co/">Official forum</a> and <a href="http://stackoverflow.com/questions/tagged/elasticsearch">StackOverflow</a> for support;</li>
-          <li class="es5"><a href="https://www.elastic.co/products/upgrade_guide">Official online migration tool</a> to help upgrading the stack to 6.x.</li>
+          <li class="es5"><a href="https://www.elastic.co/products/upgrade_guide">Official online migration tool</a> to help upgrading the stack to 6.x;</li>
+          <li class="es5 es6 es7"><a href="https://github.com/moshe/elasticsearch-comrade">Comrade</a>: a Python based Elasticsearch web admin and monitoring panel;</li>
+          <li class="es2 es5 es6 es7"><a href="https://github.com/lmenezes/cerebro">Cerebro</a>: a Java based Elasticsearch web admin;</li>
         </ul>
 
 


### PR DESCRIPTION
I've added 2 links : 

* https://github.com/moshe/elasticsearch-comrade (Elasticsearch version 5,6 and 7 support)
* https://github.com/lmenezes/cerebro (version 2, 5, 6, 7)